### PR TITLE
Let Cedar on MacOS ask for permission to use the microphone again

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -47,7 +47,10 @@
       "hardenedRuntime": true,
       "gatekeeperAssess": false,
       "entitlements": "build/entitlements.mac.plist",
-      "entitlementsInherit": "build/entitlements.mac.plist"
+      "entitlementsInherit": "build/entitlements.mac.plist",
+      "extendInfo": {
+        "NSMicrophoneUsageDescription": "Cedar requires microphone access to send audio to the other musicians in the room."
+      }
     },
     "win": {
       "publisherName": "Garrett Newman"

--- a/client/public/entitlements.mac.plist
+++ b/client/public/entitlements.mac.plist
@@ -10,5 +10,8 @@
     <!-- https://github.com/electron-userland/electron-builder/issues/3940 -->
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
+    <!-- https://github.com/electron/electron/issues/19307#issuecomment-524314643 -->
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
   </dict>
 </plist>


### PR DESCRIPTION
Since we started signing and notarizing Cedar for Mac, we needed to add a specific entitlement an entry to Info.plist (via package.json) to let Cedar ask MacOS for permission to use the mic. This is a kind of important fix.