### PR TITLE
Use redux-persist to persist redux state on a per-tab basis

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -35,6 +35,7 @@
     "react-dom": "^16.13.1",
     "react-redux": "^7.2.0",
     "react-scripts": "3.4.1",
+    "redux-persist": "^6.0.0",
     "socket.io-client": "^2.3.0",
     "typescript": "~3.7.5"
   },

--- a/client/src/app/store.ts
+++ b/client/src/app/store.ts
@@ -1,19 +1,41 @@
-import { configureStore, ThunkAction, Action } from '@reduxjs/toolkit';
+import {
+  combineReducers,
+  configureStore,
+  ThunkAction,
+  Action,
+} from '@reduxjs/toolkit';
+import { persistStore, persistReducer } from 'redux-persist';
+import storage from 'redux-persist/lib/storage'; // defaults to localStorage for web
 import audioSliceReducer from '../features/audioInput/audioSlice';
 import mediaBarReducer from '../features/mediaBar/mediaBarSlice';
 import musiciansReducer from '../features/musicians/musiciansSlice';
 import roomReducer from '../features/room/roomSlice';
 import recordingReducer from '../features/recording/recordingSlice';
 
+// NOTE(gnewman): We use sessionStorage so that we can tell redux-persist to
+// key off of all tabs uniquely. This means we can open new tabs that get fresh
+// redux states but can still have data persist on reload. Same for electron
+// windows.
+const tabID = sessionStorage.tabID
+  ? sessionStorage.tabID
+  : (sessionStorage.tabID = Math.random());
+const persistConfig = {
+  key: tabID,
+  storage,
+};
 export const store = configureStore({
-  reducer: {
-    audio: audioSliceReducer,
-    mediaBar: mediaBarReducer,
-    musicians: musiciansReducer,
-    room: roomReducer,
-    recording: recordingReducer,
-  },
+  reducer: persistReducer(
+    persistConfig,
+    combineReducers({
+      audio: audioSliceReducer,
+      mediaBar: mediaBarReducer,
+      musicians: musiciansReducer,
+      room: roomReducer,
+      recording: recordingReducer,
+    })
+  ),
 });
+export const persistor = persistStore(store);
 
 export type RootState = ReturnType<typeof store.getState>;
 export type AppThunk<ReturnType = void> = ThunkAction<

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { PersistGate } from 'redux-persist/integration/react';
 import './index.css';
 import App from './App';
-import { store } from './app/store';
+import { store, persistor } from './app/store';
 import { Provider } from 'react-redux';
 import { FeathersProvider } from './features/feathers/FeathersProvider';
 import * as serviceWorker from './serviceWorker';
@@ -15,9 +16,11 @@ import * as serviceWorker from './serviceWorker';
 // https://github.com/palantir/blueprint/issues/3979
 ReactDOM.render(
   <Provider store={store}>
-    <FeathersProvider>
-      <App />
-    </FeathersProvider>
+    <PersistGate loading={null} persistor={persistor}>
+      <FeathersProvider>
+        <App />
+      </FeathersProvider>
+    </PersistGate>
   </Provider>,
   document.getElementById('root')
 );

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -9995,6 +9995,11 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
+redux-persist@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-6.0.0.tgz#b4d2972f9859597c130d40d4b146fecdab51b3a8"
+  integrity sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==
+
 redux-thunk@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"

--- a/roadmap.txt
+++ b/roadmap.txt
@@ -87,6 +87,10 @@ Final push prior to Patreon
 + fix recording state getting broken
 + show version number
 
+Admin stuff (no code)
++ Write how-to guide
+- Demo video (~5 minutes, including musical performance)
+
 Fix bugs
 - delete recordings when done
 - Somehow, playback buffers don't always get zero'd out (still!)
@@ -106,8 +110,18 @@ Fix bugs
 - Sometimes output is choppy
 - Output becomes choppy after long recording time?
 - Sometimes screen turns white
+- Think about including the sample index of the root track that all other data
+  packets are relative to instead of adjusting based on time (should prevent
+  stream from degrading over time)
 
 Quality-of-life improvements
+- Musician stream health indicators
+  - Each musician client reports how much buffer room it has
+  - A buffer is healthier the closer that value is to secondsBetweenMusicians
+  - This is in the UI somehow as a generic "bad", "okay", "good" rating or the
+    number itself
+  - This would be extremely useful for debugging and could indicate to a group
+    if they could reduce secondsBetweenMusicians safely
 - Allow copy/paste via right-click (custom electron context menu)
 - Fix audio choppyness
 - Fix loopback calibration not working for everyone (maybe fixed)
@@ -125,6 +139,7 @@ x Standby scrollable?
 + Rename "Audience" to "Standby"
 + Don't play room audio when on Standby
 + Remove musicians when they leave the room
++ Persist redux state on a per-tab basis (nice during development)
 - Be able to leave the room and join another (need to remember to update
   channel subscriptions)
 


### PR DESCRIPTION
Title says it all--now I don't have to inspect redux state to pick the data I want to persist between refreshes. This will make testing out with large Cedar rooms much easier.